### PR TITLE
Clear the node input/output variable containers when a new trace is selected.

### DIFF
--- a/src/Components/VariableStackContainer/VariableStackContainer.js
+++ b/src/Components/VariableStackContainer/VariableStackContainer.js
@@ -67,6 +67,8 @@ export function VariableStackContainer () {
             const trace = JSON.parse(activeTrace.traces);
             setTraceInput(trace[0].adliValue);
             setTraceOutput(trace[trace.length -1].adliValue);
+            setNodeInput({});
+            setNodeOutput({});
         }
     }, [activeTrace]);
 


### PR DESCRIPTION
This PR updates the logic to clear the node's input/output variable containers when a new trace is selected.