### PR TITLE
Update the dev server port from 3011 to 3012.

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -5,7 +5,7 @@ module.exports = merge(common, {
     mode: "development",
     devtool: "cheap-module-source-map",
     devServer: {
-        port: 3011,
+        port: 3012,
         static: "./dist",
     },
 });


### PR DESCRIPTION
ASP is being modified to start the DLV and ASV as components. However, DLV and ASV use port 3011 as their dev server port. 

This PR updates the dev server port to 3012 to avoid any conflicts when packaging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the development server port from 3011 to 3012.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->