### PR TITLE
Reimplement query result parsing to account for changes to table schema. 

### DIFF
--- a/src/Providers/System.js
+++ b/src/Providers/System.js
@@ -7,13 +7,15 @@ class System {
      * @param {Object} systemInfo Information about the loaded system.
      */
     constructor (systemInfo) {
-        this.id = systemInfo.system_id + "_" + systemInfo.version;
+        this.id = systemInfo.system_id + "_" + systemInfo.system_ver;
         this.sysId = String(systemInfo.system_id);
         this.version = String(systemInfo.system_ver);
         this.programs = systemInfo.programs;
         this.deployments = systemInfo.deployments;
-
-        console.log("Created System:", this.sysId, this.version);
+        console.log("");
+        console.log("Created System");
+        console.log("System ID:", this.sysId);
+        console.log("System Version:", this.version);
     }
 }
 

--- a/src/Providers/System.js
+++ b/src/Providers/System.js
@@ -9,7 +9,7 @@ class System {
     constructor (systemInfo) {
         this.id = systemInfo.system_id + "_" + systemInfo.version;
         this.sysId = String(systemInfo.system_id);
-        this.version = String(systemInfo.version);
+        this.version = String(systemInfo.system_ver);
         this.programs = systemInfo.programs;
         this.deployments = systemInfo.deployments;
 


### PR DESCRIPTION
The table schema for the ASP database has changed when we moved from using sqlite3 to mariaDB. In this process, redundant tables have been removed and the column name and types have been updated. 

This PR updates the name of the system version in the systems table. 

Note: This is a breaking change because ASV will not work with the existing ASP workflow. I will be merging the changes to ASP shortly, I need to merge this so that I can import into the ASP before I merge that. 

If you want to use the old workflow, please use the commit before this one:
https://github.com/vishalpalaniappan/automated-system-viewer/commit/8595f5ae94150680c90371c1123d52dd5fdeb69d.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the display of system version information to ensure accurate version details are shown to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->