### PR TITLE
Add link to open log file in DLV.

### DIFF
--- a/src/Components/VariableStackContainer/VariableContainer/VariableContainer.js
+++ b/src/Components/VariableStackContainer/VariableContainer/VariableContainer.js
@@ -34,19 +34,8 @@ export function VariableContainer ({type, variables}) {
         base0F: "#a7ce8a",
     };
 
-    const getStyle = () => {
-        const hasValue = Object.keys(variables).length > 0;
-        if (type === "node" && hasValue) {
-            return {
-                border: "solid 1px #ff6767",
-            };
-        } else if (type === "trace" && hasValue) {
-            return {};
-        }
-    };
-
     return (
-        <div className="variableStackContainer w-100 h-100" style={getStyle()}>
+        <div className="variableStackContainer w-100 h-100" >
             {Object.keys(variables).length > 0 &&
                 <ReactJsonView
                     src={variables}

--- a/src/Components/VariableStackContainer/VariableStackContainer.js
+++ b/src/Components/VariableStackContainer/VariableStackContainer.js
@@ -20,8 +20,10 @@ export function VariableStackContainer () {
 
     const [traceInput, setTraceInput] = useState({});
     const [traceOutput, setTraceOutput] = useState({});
-    const [nodeInput, setNodeInput] = useState({});
-    const [nodeOutput, setNodeOutput] = useState({});
+    const [input, setInput] = useState({});
+    const [output, setOutput] = useState({});
+    const [inputValue, setInputValue] = useState({});
+    const [outputValue, setOutputValue] = useState({});
 
     const traceInputRef = useRef();
     const traceOutputRef = useRef();
@@ -48,20 +50,29 @@ export function VariableStackContainer () {
             const node = activeNode.sourceNode;
             console.log(node);
             if (node.type == "adli_output") {
-                setNodeInput({});
-                setNodeOutput(node.adliValue);
+                setInput(null);
+                setOutput(node);
+
+                setInputValue({});
+                setOutputValue(node.adliValue);
             } else if (node.type == "adli_input") {
                 if ("output" in node) {
-                    setNodeInput(node.adliValue);
-                    setNodeOutput(node.output[0].adliValue);
+                    setInput(node);
+                    setOutput(node.output[0]);
+
+                    setInputValue(node.adliValue);
+                    setOutputValue(node.output[0].adliValue);
                 } else {
-                    setNodeInput(node.adliValue);
-                    setNodeOutput({});
+                    setInput(node);
+                    setOutput(null);
+
+                    setInputValue(node.adliValue);
+                    setOutputValue({});
                 }
             }
         } else {
-            setNodeInput({});
-            setNodeOutput({});
+            setInputValue({});
+            setOutputValue({});
         }
     }, [activeNode]);
 
@@ -70,10 +81,23 @@ export function VariableStackContainer () {
             const trace = JSON.parse(activeTrace.traces);
             setTraceInput(trace[0].adliValue);
             setTraceOutput(trace[trace.length -1].adliValue);
-            setNodeInput({});
-            setNodeOutput({});
+            setInputValue({});
+            setOutputValue({});
         }
     }, [activeTrace]);
+
+    const getLinkDiv = (node) => {
+        if ("adliExecutionId" in node && "adliExecutionIndex" in node) {
+            const url = `http://localhost:3011?filePath=${node["adliExecutionId"]}.clp.zst`;
+            return <div className="float-end pe-2">
+                <a href={url} target="_blank" rel="noopener noreferrer">
+                    <BoxArrowInUpRight/> Open in DLV
+                </a>
+            </div>;
+        }
+
+        console.log(node);
+    };
 
     return (
         <div ref={variableContainerRef} className="variable-container w-100 d-flex flex-column">
@@ -93,26 +117,18 @@ export function VariableStackContainer () {
             <VerticleHandle topDiv={traceOutputRef} bottomDiv={nodeInputRef}/>
             <div className="w-100 variable-title" style={{height: TITLE_HEIGHT + "px"}}>
                 <div className="float-start">Selected Node Input</div>
-                {Object.keys(nodeInput).length > 0 &&
-                    <div className="float-end pe-2 linkDlv"><BoxArrowInUpRight/>
-                        Open in DLV
-                    </div>
-                }
+                {getLinkDiv(input)}
             </div>
             <div className="section" ref={nodeInputRef}>
-                <VariableContainer type={"node"} variables={nodeInput}/>
+                <VariableContainer type={"node"} variables={inputValue}/>
             </div>
             <VerticleHandle topDiv={nodeInputRef} bottomDiv={nodeOutputRef}/>
             <div className="w-100 variable-title" style={{height: TITLE_HEIGHT + "px"}}>
                 <div className="float-start">Selected Node Output</div>
-                {Object.keys(nodeOutput).length > 0 &&
-                    <div className="float-end pe-2 linkDlv" onClick={openLink(no)}>
-                        <BoxArrowInUpRight/> Open in DLV
-                    </div>
-                }
+                {getLinkDiv(output)}
             </div>
             <div className="section" ref={nodeOutputRef}>
-                <VariableContainer type={"node"} variables={nodeOutput}/>
+                <VariableContainer type={"node"} variables={outputValue}/>
             </div>
         </div>
     );

--- a/src/Components/VariableStackContainer/VariableStackContainer.js
+++ b/src/Components/VariableStackContainer/VariableStackContainer.js
@@ -30,7 +30,7 @@ export function VariableStackContainer () {
     const nodeInputRef = useRef();
     const nodeOutputRef = useRef();
 
-    const TITLE_HEIGHT = 20;
+    const TITLE_HEIGHT = 23;
 
     const redrawContainers = () => {
         const height = variableContainerRef.current.clientHeight;
@@ -100,6 +100,18 @@ export function VariableStackContainer () {
         console.log(node);
     };
 
+    const getTitleStyle = (node) => {
+        const style = {
+            height: TITLE_HEIGHT + "px",
+        };
+
+        if (node) {
+            style["backgroundColor"] = "#422e2f";
+        }
+
+        return style;
+    };
+
     return (
         <div ref={variableContainerRef} className="variable-container w-100 d-flex flex-column">
             <div className="w-100 variable-title" style={{height: TITLE_HEIGHT + "px"}}>
@@ -116,16 +128,20 @@ export function VariableStackContainer () {
                 <VariableContainer type={"trace"} variables={traceOutput}/>
             </div>
             <VerticleHandle topDiv={traceOutputRef} bottomDiv={nodeInputRef}/>
-            <div className="w-100 variable-title" style={{height: TITLE_HEIGHT + "px"}}>
-                <div className="float-start">Selected Node Input</div>
+            <div className="w-100 variable-title" style={getTitleStyle(input)}>
+                <div className="float-start">
+                    Selected Node Input
+                </div>
                 {getLinkDiv(input)}
             </div>
             <div className="section" ref={nodeInputRef}>
                 <VariableContainer type={"node"} variables={inputValue}/>
             </div>
             <VerticleHandle topDiv={nodeInputRef} bottomDiv={nodeOutputRef}/>
-            <div className="w-100 variable-title" style={{height: TITLE_HEIGHT + "px"}}>
-                <div className="float-start">Selected Node Output</div>
+            <div className="w-100 variable-title" style={getTitleStyle(output)}>
+                <div className="float-start">
+                    Selected Node Output
+                </div>
                 {getLinkDiv(output)}
             </div>
             <div className="section" ref={nodeOutputRef}>

--- a/src/Components/VariableStackContainer/VariableStackContainer.js
+++ b/src/Components/VariableStackContainer/VariableStackContainer.js
@@ -1,10 +1,11 @@
 import React, {useContext, useEffect, useRef, useState} from "react";
 
+import {BoxArrowInUpRight} from "react-bootstrap-icons";
+
 import ActiveNodeContext from "../../Providers/ActiveNodeContext";
 import ActiveTraceContext from "../../Providers/ActiveTraceContext";
 import {VariableContainer} from "./VariableContainer/VariableContainer";
 import {VerticleHandle} from "./VerticleHandle/VerticleHandle";
-import {BoxArrowInUpRight} from "react-bootstrap-icons";
 
 import "./VariableStackContainer.scss";
 
@@ -45,6 +46,7 @@ export function VariableStackContainer () {
     useEffect(() => {
         if (activeNode) {
             const node = activeNode.sourceNode;
+            console.log(node);
             if (node.type == "adli_output") {
                 setNodeInput({});
                 setNodeOutput(node.adliValue);
@@ -91,7 +93,11 @@ export function VariableStackContainer () {
             <VerticleHandle topDiv={traceOutputRef} bottomDiv={nodeInputRef}/>
             <div className="w-100 variable-title" style={{height: TITLE_HEIGHT + "px"}}>
                 <div className="float-start">Selected Node Input</div>
-                <div className="float-end pe-2 linkDlv"><BoxArrowInUpRight/> Open in DLV  </div>
+                {Object.keys(nodeInput).length > 0 &&
+                    <div className="float-end pe-2 linkDlv"><BoxArrowInUpRight/>
+                        Open in DLV
+                    </div>
+                }
             </div>
             <div className="section" ref={nodeInputRef}>
                 <VariableContainer type={"node"} variables={nodeInput}/>
@@ -99,7 +105,11 @@ export function VariableStackContainer () {
             <VerticleHandle topDiv={nodeInputRef} bottomDiv={nodeOutputRef}/>
             <div className="w-100 variable-title" style={{height: TITLE_HEIGHT + "px"}}>
                 <div className="float-start">Selected Node Output</div>
-                <div className="float-end pe-2 linkDlv"><BoxArrowInUpRight/> Open in DLV  </div>
+                {Object.keys(nodeOutput).length > 0 &&
+                    <div className="float-end pe-2 linkDlv" onClick={openLink(no)}>
+                        <BoxArrowInUpRight/> Open in DLV
+                    </div>
+                }
             </div>
             <div className="section" ref={nodeOutputRef}>
                 <VariableContainer type={"node"} variables={nodeOutput}/>

--- a/src/Components/VariableStackContainer/VariableStackContainer.js
+++ b/src/Components/VariableStackContainer/VariableStackContainer.js
@@ -4,6 +4,7 @@ import ActiveNodeContext from "../../Providers/ActiveNodeContext";
 import ActiveTraceContext from "../../Providers/ActiveTraceContext";
 import {VariableContainer} from "./VariableContainer/VariableContainer";
 import {VerticleHandle} from "./VerticleHandle/VerticleHandle";
+import {BoxArrowInUpRight} from "react-bootstrap-icons";
 
 import "./VariableStackContainer.scss";
 
@@ -89,14 +90,16 @@ export function VariableStackContainer () {
             </div>
             <VerticleHandle topDiv={traceOutputRef} bottomDiv={nodeInputRef}/>
             <div className="w-100 variable-title" style={{height: TITLE_HEIGHT + "px"}}>
-                Selected Node Input
+                <div className="float-start">Selected Node Input</div>
+                <div className="float-end pe-2 linkDlv"><BoxArrowInUpRight/> Open in DLV  </div>
             </div>
             <div className="section" ref={nodeInputRef}>
                 <VariableContainer type={"node"} variables={nodeInput}/>
             </div>
             <VerticleHandle topDiv={nodeInputRef} bottomDiv={nodeOutputRef}/>
             <div className="w-100 variable-title" style={{height: TITLE_HEIGHT + "px"}}>
-                Selected Node Output
+                <div className="float-start">Selected Node Output</div>
+                <div className="float-end pe-2 linkDlv"><BoxArrowInUpRight/> Open in DLV  </div>
             </div>
             <div className="section" ref={nodeOutputRef}>
                 <VariableContainer type={"node"} variables={nodeOutput}/>

--- a/src/Components/VariableStackContainer/VariableStackContainer.js
+++ b/src/Components/VariableStackContainer/VariableStackContainer.js
@@ -48,7 +48,6 @@ export function VariableStackContainer () {
     useEffect(() => {
         if (activeNode) {
             const node = activeNode.sourceNode;
-            console.log(node);
             if (node.type == "adli_output") {
                 setInput(null);
                 setOutput(node);
@@ -71,6 +70,8 @@ export function VariableStackContainer () {
                 }
             }
         } else {
+            setInput(null);
+            setOutput(null);
             setInputValue({});
             setOutputValue({});
         }
@@ -87,7 +88,7 @@ export function VariableStackContainer () {
     }, [activeTrace]);
 
     const getLinkDiv = (node) => {
-        if ("adliExecutionId" in node && "adliExecutionIndex" in node) {
+        if (node && "adliExecutionId" in node && "adliExecutionIndex" in node) {
             const url = `http://localhost:3011?filePath=${node["adliExecutionId"]}.clp.zst`;
             return <div className="float-end pe-2">
                 <a href={url} target="_blank" rel="noopener noreferrer">

--- a/src/Components/VariableStackContainer/VariableStackContainer.js
+++ b/src/Components/VariableStackContainer/VariableStackContainer.js
@@ -88,8 +88,12 @@ export function VariableStackContainer () {
     }, [activeTrace]);
 
     const getLinkDiv = (node) => {
+        console.log(node);
         if (node && "adliExecutionId" in node && "adliExecutionIndex" in node) {
-            const url = `http://localhost:3011?filePath=${node["adliExecutionId"]}.clp.zst`;
+            let url = "http://localhost:3011?";
+            url = url + `filePath=${node["adliExecutionId"]}.clp.zst&`;
+            url = url + `executionIndex=${node["adliExecutionIndex"]}`;
+            console.log(url);
             return <div className="float-end pe-2">
                 <a href={url} target="_blank" rel="noopener noreferrer">
                     <BoxArrowInUpRight/> Open in DLV

--- a/src/Components/VariableStackContainer/VariableStackContainer.scss
+++ b/src/Components/VariableStackContainer/VariableStackContainer.scss
@@ -11,3 +11,12 @@
     color: rgb(155, 155, 155);
     font-size: 12px;
 }
+
+.linkDlv {
+    color:#6995cd;
+}
+
+.linkDlv:hover{
+    text-decoration: underline;
+    cursor:pointer;
+}

--- a/src/Components/VariableStackContainer/VariableStackContainer.scss
+++ b/src/Components/VariableStackContainer/VariableStackContainer.scss
@@ -10,4 +10,5 @@
 .variable-title{
     color: rgb(155, 155, 155);
     font-size: 12px;
+    padding-left:10px;
 }

--- a/src/Components/VariableStackContainer/VariableStackContainer.scss
+++ b/src/Components/VariableStackContainer/VariableStackContainer.scss
@@ -11,12 +11,3 @@
     color: rgb(155, 155, 155);
     font-size: 12px;
 }
-
-.linkDlv {
-    color:#6995cd;
-}
-
-.linkDlv:hover{
-    text-decoration: underline;
-    cursor:pointer;
-}


### PR DESCRIPTION
This PR adds functionality to open a log file in DLV from ASP. 

![image](https://github.com/user-attachments/assets/5019c161-a4e0-404c-b86c-5f7ee3182fa7)

Note: The DLV does not support going to a specific position yet. So the link will open the log file in the last executed statement. DLV also does not have support for asyncio events, so the stack information will be inaccurate. Support will be added in a coming PR.

A future PR will provide an option in the settings menu to set DLV's URL. For now, it defaults to http://localhost:3011/.

## Validation Performed

- Started ASV
- Selected a system, version and deployment id.
- Selected a trace
- Selected a node
- Clicked the generated link to view log file in DLV
- Verified that the generated link was correct

Example Link: http://localhost:3011/?filePath=e7a39f0b-68eb-496d-82a8-2bdc3bc81226.clp.zst&executionIndex=34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a conditional "Open in DLV" link with an icon to the headers of the "Selected Node Input" and "Selected Node Output" sections when applicable.

- **Improvements**
  - Updated section headers for better alignment and clarity with added padding.
  - Enhanced display of node input and output values for improved readability.
  - Refined state management for node input and output to better track metadata and values separately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->