### PR TITLE
Update the keys used to build the URL.

### DIFF
--- a/src/Components/VariableStackContainer/VariableStackContainer.js
+++ b/src/Components/VariableStackContainer/VariableStackContainer.js
@@ -88,20 +88,16 @@ export function VariableStackContainer () {
     }, [activeTrace]);
 
     const getLinkDiv = (node) => {
-        console.log(node);
-        if (node && "adliExecutionId" in node && "adliExecutionIndex" in node) {
+        if (node && "logFileIndex" in node && "logFileId" in node) {
             let url = "http://localhost:3011?";
-            url = url + `filePath=${node["adliExecutionId"]}.clp.zst&`;
-            url = url + `executionIndex=${node["adliExecutionIndex"]}`;
-            console.log(url);
+            url = url + `filePath=${node["logFileId"]}.clp.zst&`;
+            url = url + `executionIndex=${node["logFileIndex"]}`;
             return <div className="float-end pe-2">
                 <a href={url} target="_blank" rel="noopener noreferrer">
                     <BoxArrowInUpRight/> Open in DLV
                 </a>
             </div>;
         }
-
-        console.log(node);
     };
 
     const getTitleStyle = (node) => {


### PR DESCRIPTION
This PR updates the keys used to build the URL to open the log file using the Diagnostic Log Viewer (DLV). 

The new keys are `logFileId` and `logFileIndex`. They reflect the position of the io node in the log file that it was scanned from.

# Validation Performed 
- Started ASP
- Selected a trace in ASV
- Selected a node
- Clicked link to open in DLV and inspected the position, verified that the position was correct.
- Repeated steps for three more nodes.

Note: To run this test, PR #44 of the ASP repo was used. It has not been merged yet but it will be merged shortly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated link generation to use correct properties for log file navigation.

- **Chores**
  - Removed unnecessary console logging from the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->